### PR TITLE
add slack and notion tools

### DIFF
--- a/apis/notion/code/.gitignore
+++ b/apis/notion/code/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+node_modules/

--- a/apis/notion/code/README.md
+++ b/apis/notion/code/README.md
@@ -1,0 +1,10 @@
+# Notion Integration
+
+This is a collection of tools that interact with Notion.
+
+## Usage
+
+These tools should not be used directly. Instead, use one of the following:
+
+- github.com/gptscript-ai/tools/apis/notion/read
+- github.com/gptscript-ai/tools/apis/notion/write

--- a/apis/notion/code/index.js
+++ b/apis/notion/code/index.js
@@ -1,0 +1,52 @@
+import {APIResponseError, Client} from "@notionhq/client"
+import {createPage, printPageProperties, recursivePrintChildBlocks} from "./src/pages.js"
+import {printDatabaseRow} from "./src/database.js";
+import {printSearchResults} from "./src/search.js";
+
+if (process.argv.length !== 3) {
+    console.error('Usage: node index.js <command>')
+    process.exit(1)
+}
+
+const command = process.argv[2]
+const token = process.env.NOTION_TOKEN
+
+const notion = new Client({auth: token})
+
+async function main() {
+    try {
+        switch (command) {
+            case "search":
+                printSearchResults(await notion.search({query: process.env.QUERY}))
+                break
+            case "getPage":
+                await printPageProperties(notion, process.env.ID)
+                console.log("Page Contents:")
+                await recursivePrintChildBlocks(notion, process.env.ID)
+                break
+            case "getDatabase":
+                const response = await notion.databases.query({database_id: process.env.ID})
+                for (const row of response.results) {
+                    if (row.object === "page") {
+                        await printDatabaseRow(notion, row)
+                    }
+                }
+                break
+            case "createPage":
+                await createPage(notion, process.env.NAME, process.env.CONTENTS, process.env.PARENTPAGEID)
+                break
+            default:
+                console.log(`Unknown command: ${command}`)
+                process.exit(1)
+        }
+    } catch (error) {
+        // We use console.log instead of console.error here so that it goes to stdout
+        if (error instanceof APIResponseError) {
+            console.log(error.message)
+        } else {
+            console.log("Got an unknown error")
+        }
+    }
+}
+
+await main()

--- a/apis/notion/code/package-lock.json
+++ b/apis/notion/code/package-lock.json
@@ -1,0 +1,144 @@
+{
+  "name": "notion",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "notion",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@notionhq/client": "^2.2.14"
+      }
+    },
+    "node_modules/@notionhq/client": {
+      "version": "2.2.14",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-2.2.14.tgz",
+      "integrity": "sha512-oqUefZtCiJPCX+74A1Os9OVTef3fSnVWe2eVQtU1HJSD+nsfxfhwvDKnzJTh2Tw1ZHKLxpieHB/nzGdY+Uo12A==",
+      "dependencies": {
+        "@types/node-fetch": "^2.5.10",
+        "node-fetch": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.11.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
+      "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  }
+}

--- a/apis/notion/code/package.json
+++ b/apis/notion/code/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "notion",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "type": "module",
+  "author": "",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@notionhq/client": "^2.2.14"
+  }
+}

--- a/apis/notion/code/src/database.js
+++ b/apis/notion/code/src/database.js
@@ -1,0 +1,164 @@
+import {richTextArrayToString} from "./pages.js";
+
+export async function printDatabaseRow(client, row) {
+    let title = ""
+    let result = ""
+    for (const [propertyName, property] of Object.entries(row.properties)) {
+        if (property.type === "title") {
+            title = `| ${richTextArrayToString(property.title)}(ID: ${row.id}) |`
+        } else {
+            result += ` ${propertyName}: ${await getPropertyString(client, property)} |`
+        }
+    }
+    console.log(title + result)
+}
+
+export async function getPropertyString(client, property) {
+    let result = ""
+    switch (property.type) {
+        case "checkbox":
+            result += property.checkbox ? "[x]" : "[ ]"
+            break
+        case "created_by":
+            result += `${property.created_by.name} (ID: ${property.created_by.id})`
+            break
+        case "created_time":
+            result += property.created_time
+            break
+        case "date":
+            result += dateToString(property.date)
+            break
+        case "email":
+            if (property.email !== null) {
+                result += property.email
+            }
+            break
+        case "files":
+            result += `[${property.files.map(fileToString).join(", ")}]`
+            break
+        case "formula":
+            switch (property.formula.type) {
+                case "number":
+                    result += property.formula.number
+                    break
+                case "string":
+                    result += property.formula.string
+                    break
+                case "date":
+                    result += dateToString(property.formula.date)
+                    break
+                case "boolean":
+                    result += property.formula.boolean ? "true" : "false"
+                    break
+            }
+            break
+        case "last_edited_by":
+            result += `${property.last_edited_by.name} (ID: ${property.last_edited_by.id})`
+            break
+        case "last_edited_time":
+            result += property.last_edited_time
+            break
+        case "multi_select":
+            result += `[${property.multi_select.map(ms => ms.name).join(", ")}]`
+            break
+        case "number":
+            if (property.number !== null) {
+                result += property.number
+            }
+            break
+        case "people":
+            result += `[${property.people.map(p => p.name).join(", ")}]`
+            break
+        case "phone_number":
+            if (property.phone_number !== null) {
+                result += property.phone_number
+            }
+            break
+        case "relation":
+            let pageNames = []
+            for (const r of property.relation) {
+                pageNames.push(await getPageNameByID(client, r.id))
+            }
+            result += `[${pageNames.join(", ")}]`
+            break
+        case "rich_text":
+            result += property.rich_text.map(r => r.plain_text).join("")
+            break
+        case "rollup":
+            switch (property.rollup.type) {
+                case "number":
+                    result += property.rollup.number
+                    break
+                case "array":
+                    // The type inside of this array can never be another rollup, so we don't need to worry about infinite recursion
+                    let propertyStrings = []
+                    for (const a of property.rollup.array) {
+                        propertyStrings.push(await getPropertyString(client, a))
+                    }
+                    result += `[${propertyStrings.join(", ")}]`
+                    break
+                case "date":
+                    result += dateToString(property.rollup.date)
+                    break
+            }
+            break
+        case "select":
+            if (property.select !== null) {
+                result += property.select.name
+            }
+            break
+        case "status":
+            result += property.status.name
+            break
+        case "title":
+            result += richTextArrayToString(property.title)
+            break
+        case "unique_id":
+            if (property.unique_id !== null) {
+                if (property.unique_id.prefix !== null) {
+                    result += `${property.unique_id.prefix}-${property.unique_id.number}`
+                } else {
+                    result += property.unique_id.number
+                }
+            }
+            break
+        case "url":
+            if (property.url !== null) {
+                result += property.url
+            }
+            break
+    }
+    return result
+}
+
+function fileToString(file) {
+    let result = ""
+    if (file.type === "file") {
+        result = `${file.name}: ${file.file.url} (expires ${file.file.expiry_time})`
+    } else if (file.type === "external") {
+        result = `${file.name} (external): ${file.external.url}`
+    }
+    return result
+}
+
+function dateToString(date) {
+    let result = ""
+    if (date === null) {
+        return result
+    }
+
+    if (date.end !== null) {
+        result = `${date.start} - ${date.end}`
+    } else {
+        result = `${date.start}`
+    }
+    if (date.time_zone !== null && date.time_zone !== "") {
+        result += ` (${date.time_zone})`
+    }
+    return result
+}
+
+async function getPageNameByID(client, id) {
+    const response = await client.pages.retrieve({page_id: id})
+    return response.properties.Name.title[0].plain_text
+}

--- a/apis/notion/code/src/pages.js
+++ b/apis/notion/code/src/pages.js
@@ -1,0 +1,222 @@
+import {getPropertyString} from "./database.js"
+
+export async function createPage(client, name, contents, parentPageId) {
+    const page = await client.pages.create({
+        parent: {
+            page_id: parentPageId,
+        },
+        properties: {
+            title: [{type: "text", text: {content: name}}],
+        },
+        children: [{
+            paragraph: {
+                rich_text: [{type: "text", text: {content: contents}}],
+            }
+        }]
+    })
+    console.log(`Created page with ID: ${page.id}`)
+}
+
+export async function printPageProperties(client, id) {
+    const page = await client.pages.retrieve({page_id: id})
+    console.log("Page Properties:")
+    for (const [propertyName, property] of Object.entries(page.properties)) {
+        console.log(`${propertyName}: ${await getPropertyString(client, property)}`)
+    }
+    console.log("")
+}
+
+export async function recursivePrintChildBlocks(client, id, indentation = 0) {
+    const blocks = await client.blocks.children.list({block_id: id})
+    for (let b of blocks.results) {
+        // Tables are complicated, so we handle them completely separately
+        if (b.type === "table") {
+            await printTable(client, b)
+            continue
+        }
+
+        await printBlock(client, b, indentation)
+        if (b.has_children && b.type !== "child_page" && b.type !== "synced_block") {
+            await recursivePrintChildBlocks(client, b.id, indentation + 2)
+        }
+    }
+}
+
+async function printBlock(client, b, indentation) {
+    let result = ""
+    if (indentation > 0) {
+        result += " ".repeat(indentation)
+    }
+    switch (b.type) {
+        case "bookmark":
+            if (b.bookmark.caption !== null && richTextArrayToString(b.bookmark.caption) !== "") {
+                result += `Bookmark: ${b.bookmark.url} (${richTextArrayToString(b.bookmark.caption)})`
+            } else {
+                result += `Bookmark: ${b.bookmark.url}`
+            }
+            break
+        case "bulleted_list_item":
+            result += `- ${richTextArrayToString(b.bulleted_list_item.rich_text)}`
+            break
+        case "callout":
+            result += `> ${richTextArrayToString(b.callout.rich_text)}`
+            break
+        case "child_database":
+            result += `Child Database: ${b.child_database.title}`
+            break
+        case "child_page":
+            result += `Child Page: ${b.child_page.title}`
+            break
+        case "code":
+            if (b.code.language !== null) {
+                result += "```" + b.code.language + "\n"
+            } else {
+                result += "```\n"
+            }
+            result += richTextArrayToString(b.code.rich_text)
+            result += "\n```"
+            if (b.code.caption !== null && richTextArrayToString(b.code.caption) !== "") {
+                result += `\n(${richTextArrayToString(b.code.caption)})`
+            }
+            break
+        case "database":
+            // TODO - test this one out
+            //   Is there even a way to get a database block?
+            result += `Mentioned Database ID: ${b.database.id}`
+            break
+        case "date":
+            if (b.date.end !== null) {
+                result += `${b.date.start} - ${b.date.end}`
+            } else {
+                result += b.date.start
+            }
+            break
+        case "divider":
+            result += "-------------------------------------"
+            break
+        case "embed":
+            result += `Embed: ${b.embed.url}`
+            break
+        case "equation":
+            result += `Equation: ${b.equation.expression}`
+            break
+        case "file":
+            result += fileToString("File", b.file)
+            break
+        case "heading_1":
+            result += `# ${richTextArrayToString(b.heading_1.rich_text)}`
+            break
+        case "heading_2":
+            result += `## ${richTextArrayToString(b.heading_2.rich_text)}`
+            break
+        case "heading_3":
+            result += `### ${richTextArrayToString(b.heading_3.rich_text)}`
+            break
+        case "image":
+            result += fileToString("Image", b.image)
+            break
+        case "link_preview":
+            result += b.link_preview.url
+            break
+        case "numbered_list_item":
+            result += `1. ${richTextArrayToString(b.numbered_list_item.rich_text)}`
+            break
+        case "page":
+            result += `Mentioned Page ID: ${b.page.id}`
+            break
+        case "paragraph":
+            result += richTextArrayToString(b.paragraph.rich_text)
+            break
+        case "pdf":
+            result += fileToString("PDF", b.pdf)
+            break
+        case "quote":
+            result += "\"\"\"\n"
+            result += richTextArrayToString(b.quote.rich_text)
+            result += "\n\"\"\""
+            break
+        case "synced_block":
+            if (b.synced_block.synced_from !== null) {
+                await recursivePrintChildBlocks(client, b.synced_block.synced_from.block_id, indentation)
+            }
+            break
+        case "to_do":
+            if (b.to_do.checked) {
+                result += `[x] ${richTextArrayToString(b.to_do.rich_text)}`
+            } else {
+                result += `[ ] ${richTextArrayToString(b.to_do.rich_text)}`
+            }
+            break
+        case "toggle":
+            result += `> ${richTextArrayToString(b.toggle.rich_text)}`
+            break
+        case "user":
+            if (b.user.name !== null && b.user.name !== "") {
+                result += `Mentioned User: ${b.user.name} (ID: ${b.user.id})`
+            } else {
+                result += `Mentioned User ID: ${b.user.id}`
+            }
+            break
+        case "video":
+            result += fileToString("Video", b.video)
+            break
+    }
+    result = result.replaceAll("\n", "\n" + " ".repeat(indentation))
+    console.log(result)
+}
+
+export function richTextArrayToString(richTextArray) {
+    let result = ""
+    for (let r of richTextArray) {
+        result += r.plain_text + " "
+    }
+    return result
+}
+
+function fileToString(prefix, file) {
+    let result = ""
+    if (file.type === "file") {
+        result = `${prefix}: ${file.file.url} (expires ${file.file.expiry_time})`
+    } else if (file.type === "external") {
+        result = `External ${prefix}: ${file.external.url}`
+    }
+    if (file.caption !== null && richTextArrayToString(file.caption) !== "") {
+        result += ` (${richTextArrayToString(file.caption)})`
+    }
+    return result
+}
+
+async function printTable(client, table) {
+    const children = await client.blocks.children.list({block_id: table.id})
+    if (table.table.has_column_header && children.results.length > 0) {
+        printTableRow(children.results[0].table_row, table.table.has_row_header, true)
+        for (let i = 1; i < children.results.length; i++) {
+            printTableRow(children.results[i].table_row, table.table.has_row_header, false)
+        }
+    } else {
+        for (let r of children.results) {
+            printTableRow(r.table_row, table.table.has_row_header, false)
+        }
+    }
+}
+
+function printTableRow(row, boldFirst, boldAll) {
+    let result = "|"
+    if (boldAll) {
+        for (let c of row.cells) {
+            result += ` **${richTextArrayToString(c)}** |`
+        }
+        let len = result.length
+        result += "\n|" + "-".repeat(len - 2) + "|"
+    } else if (boldFirst && row.cells.length > 0) {
+        result += ` **${richTextArrayToString(row.cells[0])}** |`
+        for (let i = 1; i < row.cells.length; i++) {
+            result += ` ${richTextArrayToString(row.cells[i])} |`
+        }
+    } else {
+        for (let c of row.cells) {
+            result += ` ${richTextArrayToString(c)} |`
+        }
+    }
+    console.log(result)
+}

--- a/apis/notion/code/src/search.js
+++ b/apis/notion/code/src/search.js
@@ -1,0 +1,64 @@
+export function printSearchResults(res) {
+    let pages = []
+    let databases = []
+    for (let r of res.results) {
+        switch (r.object) {
+            case "page":
+                pages.push(r)
+                break
+            case "database":
+                databases.push(r)
+                break
+        }
+    }
+    if (pages.length > 0) {
+        printPages(pages)
+    }
+    console.log("")
+    if (databases.length > 0) {
+        printDatabases(databases)
+    }
+}
+
+function printPages(pages) {
+    console.log("Pages:")
+    for (let page of pages) {
+        console.log(`- ID: ${page.id}`)
+        if (page.properties.title !== undefined && page.properties.title.title.length > 0) {
+            console.log(`  Title: ${page.properties.title.title[0].plain_text}`)
+        } else if (page.properties.Name !== undefined && page.properties.Name.title.length > 0) {
+            console.log(`  Name: ${page.properties.Name.title[0].plain_text}`)
+        }
+        console.log(`  URL: ${page.url}`)
+        console.log(`  Parent Type: ${page.parent.type}`)
+        if (page.parent.type === "database_id") {
+            console.log(`  Parent Database ID: ${page.parent.database_id}`)
+        } else if (page.parent.type === "page_id") {
+            console.log(`  Parent Page ID: ${page.parent.page_id}`)
+        } else if (page.parent.type === "block_id") {
+            console.log(`  Parent Block ID: ${page.parent.block_id}`)
+        }
+    }
+}
+
+function printDatabases(dbs) {
+    console.log("Databases:")
+    for (let db of dbs) {
+        console.log(`- Title: ${db.title[0].plain_text}`)
+        console.log(`  ID: ${db.id}`)
+        console.log(`  URL: ${db.url}`)
+        if (db.description.length > 0) {
+            console.log(`  Description: ${db.description[0].plain_text}`)
+        }
+        if (db.parent.type !== "") {
+            console.log(`  Parent Type: ${db.parent.type}`)
+        }
+        if (db.parent.type === "database_id") {
+            console.log(`  Parent Database ID: ${db.parent.database_id}`)
+        } else if (db.parent.type === "page_id") {
+            console.log(`  Parent Page ID: ${db.parent.page_id}`)
+        } else if (db.parent.type === "block_id") {
+            console.log(`  Parent Block ID: ${db.parent.block_id}`)
+        }
+    }
+}

--- a/apis/notion/code/tool.gpt
+++ b/apis/notion/code/tool.gpt
@@ -1,0 +1,28 @@
+Name: getPage
+Description: Gets the contents of a page in Notion
+Args: id: the ID of the page to get
+
+#!/usr/bin/env node --no-warnings ${GPTSCRIPT_TOOL_DIR}/index.js getPage
+
+---
+Name: getDatabase
+Description: Gets the contents of a database in Notion
+Args: id: the ID of the database to get
+
+#!/usr/bin/env node --no-warnings ${GPTSCRIPT_TOOL_DIR}/index.js getDatabase
+
+---
+Name: search
+Description: Searches a Notion workspace for pages and databases
+Args: query: the search query
+
+#!/usr/bin/env node --no-warnings ${GPTSCRIPT_TOOL_DIR}/index.js search
+
+---
+Name: createPage
+Description: Creates a new page in Notion
+Args: name: the name of the page to create
+Args: contents: the contents of the page in plain text
+Args: parentPageId: ID of the page that will be the parent of the new page
+
+#!/usr/bin/env node --no-warnings ${GPTSCRIPT_TOOL_DIR}/index.js createPage

--- a/apis/notion/read/tool.gpt
+++ b/apis/notion/read/tool.gpt
@@ -1,0 +1,5 @@
+Name: Read Notion
+Share Credential: github.com/gptscript-ai/gateway-oauth2 as notion.read with NOTION_TOKEN as env and notion as integration
+Share Tools: getPage from github.com/gptscript-ai/tools/apis/notion/code
+Share Tools: getDatabase from github.com/gptscript-ai/tools/apis/notion/code
+Share Tools: search from github.com/gptscript-ai/tools/apis/notion/code

--- a/apis/notion/write/tool.gpt
+++ b/apis/notion/write/tool.gpt
@@ -1,0 +1,6 @@
+Name: Notion
+Share Credential: github.com/gptscript-ai/gateway-oauth2 as notion.read with NOTION_TOKEN as env and notion as integration
+Share Tools: getPage from github.com/gptscript-ai/tools/apis/notion/code
+Share Tools: getDatabase from github.com/gptscript-ai/tools/apis/notion/code
+Share Tools: search from github.com/gptscript-ai/tools/apis/notion/code
+Share Tools: createPage from github.com/gptscript-ai/tools/apis/notion/code

--- a/apis/slack/code/.gitignore
+++ b/apis/slack/code/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+node_modules/

--- a/apis/slack/code/README.md
+++ b/apis/slack/code/README.md
@@ -1,0 +1,10 @@
+# Slack Integration
+
+This is a collection of tools that interact with Slack workspaces.
+
+## Usage
+
+These tools should not be used directly. Instead, use one of the following:
+
+- github.com/gptscript-ai/tools/apis/slack/read
+- github.com/gptscript-ai/tools/apis/slack/write

--- a/apis/slack/code/index.js
+++ b/apis/slack/code/index.js
@@ -1,0 +1,30 @@
+import {WebClient} from '@slack/web-api'
+import {getChannelHistory, listChannels, search, sendMessage} from "./src/tools.js";
+
+if (process.argv.length !== 3) {
+    console.error('Usage: node index.js <command>')
+    process.exit(1)
+}
+
+const command = process.argv[2]
+const token = process.env.SLACK_TOKEN
+
+const webClient = new WebClient(token)
+
+switch (command) {
+    case "listChannels":
+        await listChannels(webClient)
+        break
+    case "getChannelHistory":
+        await getChannelHistory(webClient, process.env.CHANNELID, process.env.LIMIT)
+        break
+    case "searchMessages":
+        await search(webClient, process.env.QUERY)
+        break
+    case "sendMessage":
+        await sendMessage(webClient, process.env.CHANNELID, process.env.TEXT)
+        break
+    default:
+        console.error(`Unknown command: ${command}`)
+        process.exit(1)
+}

--- a/apis/slack/code/package-lock.json
+++ b/apis/slack/code/package-lock.json
@@ -1,0 +1,272 @@
+{
+  "name": "gptscript-slack-read",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "gptscript-slack-read",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@slack/web-api": "^7.3.2"
+      }
+    },
+    "node_modules/@slack/logger": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.0.tgz",
+      "integrity": "sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=18.0.0"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-yFewzUomYZ2BYaGJidPuIgjoYj5wqPDmi7DLSaGIkf+rCi4YZ2Z3DaiYIbz7qb/PL2NmamWjCvB7e9ArI5HkKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/web-api": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.3.2.tgz",
+      "integrity": "sha512-hyxwSsUhpOEVN5ORB3ne7TAXQwXl0wxBAyNTCfp4Qc/o9rpEEvY4kfsx7mZF5AhYPcdEeI1XP2bSFrh3W/HGKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^4.0.0",
+        "@slack/types": "^2.9.0",
+        "@types/node": ">=18.0.0",
+        "@types/retry": "0.12.0",
+        "axios": "^1.6.5",
+        "eventemitter3": "^5.0.1",
+        "form-data": "^4.0.0",
+        "is-electron": "2.2.2",
+        "is-stream": "^2",
+        "p-queue": "^6",
+        "p-retry": "^4",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.1.0.tgz",
+      "integrity": "sha512-AOmuRF0R2/5j1knA3c6G3HOk523Ga+l+ZXltX8SF1+5oqcXijjfTd8fY3XRZqSihEu9XhtQnKYLmkFaoxgsJHw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.13.0"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/is-electron": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.13.0.tgz",
+      "integrity": "sha512-xtFJHudx8S2DSoujjMd1WeWvn7KKWFRESZTMeL1RptAYERu29D6jphMjjY+vn96jvN3kVPDNxU/E13VTaXj6jg==",
+      "license": "MIT"
+    }
+  }
+}

--- a/apis/slack/code/package.json
+++ b/apis/slack/code/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "gptscript-slack-read",
+  "version": "0.1.0",
+  "description": "GPTScript tool for read-only access to the Slack API.",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "github.com/gptscript-ai/integrations"
+  },
+  "author": "Acorn Labs",
+  "license": "Apache-2.0",
+  "type": "module",
+  "dependencies": {
+    "@slack/web-api": "^7.3.2"
+  }
+}

--- a/apis/slack/code/src/tools.js
+++ b/apis/slack/code/src/tools.js
@@ -1,0 +1,96 @@
+export async function listChannels(webClient) {
+    const channels = await webClient.conversations.list({limit: 100})
+    channels.channels.forEach(channel => {
+        console.log(`${channel.name} (ID: ${channel.id})`)
+    })
+}
+
+export async function getChannelHistory(webClient, channelId, limit) {
+    const history = await webClient.conversations.history({channel: channelId, limit: limit})
+    if (!history.ok) {
+        console.error(`Failed to retrieve chat history: ${history.error}`)
+        process.exit(1)
+    } else if (history.messages.length === 0) {
+        console.log('No messages found')
+        return
+    }
+
+    const userMap = await getUserMap(webClient)
+
+    for (const message of history.messages) {
+        const time = new Date(parseFloat(message.ts) * 1000)
+        console.log(`${time.toLocaleString()}: ${userMap[message.user]}: ${message.text}`)
+        if (message.reply_count > 0) {
+            console.log(`  ${message.reply_count} ${replyString(message.reply_count)}:`)
+            const replies = await webClient.conversations.replies({channel: channelId, ts: message.ts})
+            for (const reply of replies.messages) {
+                if (reply.ts === message.ts) {
+                    continue
+                }
+
+                const replyTime = new Date(parseFloat(reply.ts) * 1000)
+                console.log(`  ${replyTime.toLocaleString()}: ${userMap[reply.user]}: ${reply.text}`)
+            }
+        }
+    }
+}
+
+
+export async function search(webClient, query) {
+    const result = await webClient.search.all({
+        query: query,
+    })
+
+    if (!result.ok) {
+        console.error(`Failed to search messages: ${result.error}`)
+        process.exit(1)
+    }
+
+    if (result.messages.matches.length === 0) {
+        console.log('No messages found')
+        return
+    }
+
+    const userMap = await getUserMap(webClient)
+
+    for (const message of result.messages.matches) {
+        const time = new Date(parseFloat(message.ts) * 1000)
+        console.log(`${time.toLocaleString()}: ${userMap[message.user]} in #${message.channel.name}: ${message.text}`)
+    }
+}
+
+export async function sendMessage(webClient, channelId, text) {
+    const result = await webClient.chat.postMessage({
+        channel: channelId,
+        text: text,
+    })
+
+    if (!result.ok) {
+        console.error(`Failed to send message: ${result.error}`)
+        process.exit(1)
+    }
+    console.log('Message sent successfully')
+}
+
+// Helper functions below
+
+function replyString(count) {
+    return count === 1 ? 'reply' : 'replies'
+}
+
+async function getUserMap(webClient) {
+    // Get the list of users. We will need this in order to look up usernames.
+    const users = await webClient.users.list()
+    if (!users.ok) {
+        console.error(`Failed to retrieve user list: ${users.error}`)
+        process.exit(1)
+    }
+
+    // Create a map of user IDs to usernames.
+    const userMap = {}
+    users.members.forEach(user => {
+        userMap[user.id] = user.name
+    })
+
+    return userMap
+}

--- a/apis/slack/code/tool.gpt
+++ b/apis/slack/code/tool.gpt
@@ -1,0 +1,27 @@
+Name: list_channels
+Description: List all channels in the Slack workspace. Returns the name and ID for each channel
+
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js listChannels
+
+---
+Name: get_channel_history
+Description: Get the chat history for a channel in the Slack workspace
+Param: channelid: the ID of the channel to get the history for
+Param: limit: the number of messages to return
+
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js getChannelHistory
+
+---
+Name: search_messages
+Description: Search for messages in the Slack workspace
+Param: query: the search query
+
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js searchMessages
+
+---
+Name: send_message
+Description: Send a message to a channel in the Slack workspace
+Param: channelid: the ID of the channel to send the message to
+Param: text: the text to send
+
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js sendMessage

--- a/apis/slack/read/tool.gpt
+++ b/apis/slack/read/tool.gpt
@@ -1,0 +1,5 @@
+Name: Read Slack
+Share Credential: github.com/gptscript-ai/gateway-oauth2 as slack.read with SLACK_TOKEN as env and slack as integration and "channels:history channels:read files:read im:read search:read team:read users:read" as scope
+Share Tools: list_channels from github.com/gptscript-ai/tools/apis/slack/code
+Share Tools: get_channel_history from github.com/gptscript-ai/tools/apis/slack/code
+Share Tools: search_messages from github.com/gptscript-ai/tools/apis/slack/code

--- a/apis/slack/write/tool.gpt
+++ b/apis/slack/write/tool.gpt
@@ -1,0 +1,6 @@
+Name: Slack
+Share Credential: github.com/gptscript-ai/gateway-oauth2 as slack.write with SLACK_TOKEN as env and slack as integration and "channels:history channels:read files:read im:read search:read team:read users:read chat:write" as scope
+Share Tools: list_channels from github.com/gptscript-ai/tools/apis/slack/code
+Share Tools: get_channel_history from github.com/gptscript-ai/tools/apis/slack/code
+Share Tools: search_messages from github.com/gptscript-ai/tools/apis/slack/code
+Share Tools: send_message from github.com/gptscript-ai/tools/apis/slack/code


### PR DESCRIPTION
This PR adds tool sets for Slack and Notion, split into separate read and write tools. These are both code-based and use each service's SDK, since they don't have (up-to-date) OpenAPI files. Both the read and write tools share the same code tool, so I set up the directories like `apis/{slack,notion}/{read,write,code}`, and made the read and write tools reference the code tool. I think this structure makes sense, but let me know if you have a better idea.