### PR TITLE
Quote command arguments in aws cli

### DIFF
--- a/clis/aws/tool.gpt
+++ b/clis/aws/tool.gpt
@@ -16,4 +16,5 @@ else
   else
     echo "The user has version 2 of the aws cli installed. Use version 2 syntax."
   fi
+    echo "Quote the command arguments to be shell safe"
 fi

--- a/clis/aws/tool.gpt
+++ b/clis/aws/tool.gpt
@@ -16,5 +16,5 @@ else
   else
     echo "The user has version 2 of the aws cli installed. Use version 2 syntax."
   fi
-    echo "Quote the command arguments to be shell safe"
+    echo "quote aws cli arguments to be shell safe"
 fi


### PR DESCRIPTION
Without this chatgpt was not properly quoting the command arguments for aws cli, this resulted in wrong commands, when ' or " were part of the command argument. 

I discovered this issue when playing around with aws athena.