### PR TITLE
fix: improve outlook mail search

### DIFF
--- a/apis/outlook/mail/code/main.go
+++ b/apis/outlook/mail/code/main.go
@@ -35,7 +35,7 @@ func main() {
 			os.Exit(1)
 		}
 	case "searchMessages":
-		if err := commands.SearchMessages(context.Background(), os.Getenv("QUERY"), os.Getenv("FOLDER_ID")); err != nil {
+		if err := commands.SearchMessages(context.Background(), os.Getenv("QUERY"), os.Getenv("FROM_ADDRESS"), os.Getenv("FROM_NAME"), os.Getenv("FOLDER_ID")); err != nil {
 			fmt.Printf("failed to search messages: %v\n", err)
 			os.Exit(1)
 		}

--- a/apis/outlook/mail/code/main.go
+++ b/apis/outlook/mail/code/main.go
@@ -35,7 +35,7 @@ func main() {
 			os.Exit(1)
 		}
 	case "searchMessages":
-		if err := commands.SearchMessages(context.Background(), os.Getenv("QUERY"), os.Getenv("FROM_ADDRESS"), os.Getenv("FROM_NAME"), os.Getenv("FOLDER_ID")); err != nil {
+		if err := commands.SearchMessages(context.Background(), os.Getenv("SUBJECT"), os.Getenv("FROM_ADDRESS"), os.Getenv("FROM_NAME"), os.Getenv("FOLDER_ID")); err != nil {
 			fmt.Printf("failed to search messages: %v\n", err)
 			os.Exit(1)
 		}

--- a/apis/outlook/mail/code/pkg/commands/searchMessages.go
+++ b/apis/outlook/mail/code/pkg/commands/searchMessages.go
@@ -10,13 +10,13 @@ import (
 	"github.com/gptscript-ai/tools/apis/outlook/mail/code/pkg/printers"
 )
 
-func SearchMessages(ctx context.Context, query, folderID string) error {
+func SearchMessages(ctx context.Context, query, fromAddress, fromName, folderID string) error {
 	c, err := client.NewClient(global.ReadOnlyScopes)
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)
 	}
 
-	messages, err := graph.SearchMessages(ctx, c, query, folderID)
+	messages, err := graph.SearchMessages(ctx, c, query, fromAddress, fromName, folderID)
 	if err != nil {
 		return fmt.Errorf("failed to search messages: %w", err)
 	}

--- a/apis/outlook/mail/code/pkg/commands/searchMessages.go
+++ b/apis/outlook/mail/code/pkg/commands/searchMessages.go
@@ -10,17 +10,21 @@ import (
 	"github.com/gptscript-ai/tools/apis/outlook/mail/code/pkg/printers"
 )
 
-func SearchMessages(ctx context.Context, query, fromAddress, fromName, folderID string) error {
+func SearchMessages(ctx context.Context, subject, fromAddress, fromName, folderID string) error {
 	c, err := client.NewClient(global.ReadOnlyScopes)
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)
 	}
 
-	messages, err := graph.SearchMessages(ctx, c, query, fromAddress, fromName, folderID)
+	messages, err := graph.SearchMessages(ctx, c, subject, fromAddress, fromName, folderID)
 	if err != nil {
 		return fmt.Errorf("failed to search messages: %w", err)
 	}
 
-	printers.PrintMessages(messages, false)
+	if len(messages) == 0 {
+		fmt.Println("no messages found")
+	} else {
+		printers.PrintMessages(messages, false)
+	}
 	return nil
 }

--- a/apis/outlook/mail/code/pkg/graph/mail.go
+++ b/apis/outlook/mail/code/pkg/graph/mail.go
@@ -45,9 +45,9 @@ func SearchMessages(ctx context.Context, client *msgraphsdkgo.GraphServiceClient
 	// The search results from $search are often not all that great for whatever reason. The subject line is probably more important.
 	// So we combine the results with the subject ones first, and then dedupe and return.
 	var (
-		subjectResult models.MessageCollectionResponseable = &models.MessageCollectionResponse{}
+		subjectResult models.MessageCollectionResponseable
 		subjectErr    error
-		result        models.MessageCollectionResponseable = &models.MessageCollectionResponse{}
+		result        models.MessageCollectionResponseable
 		err           error
 		filter        []string
 		search        string
@@ -106,10 +106,10 @@ func SearchMessages(ctx context.Context, client *msgraphsdkgo.GraphServiceClient
 	}
 
 	var fullResults []models.Messageable
-	if subjectResult != nil {
+	if subjectResult != nil && subjectResult.GetValue() != nil {
 		fullResults = append(fullResults, subjectResult.GetValue()...)
 	}
-	if result != nil {
+	if result != nil && result.GetValue() != nil {
 		fullResults = append(fullResults, result.GetValue()...)
 	}
 	return util.Dedupe(fullResults, func(result models.Messageable) string {

--- a/apis/outlook/mail/code/pkg/graph/mail.go
+++ b/apis/outlook/mail/code/pkg/graph/mail.go
@@ -73,6 +73,9 @@ func SearchMessages(ctx context.Context, client *msgraphsdkgo.GraphServiceClient
 		})
 	}
 
+	if subjectErr != nil {
+		return nil, fmt.Errorf("failed to search messages by subject: %w", subjectErr)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to search messages: %w", err)
 	}

--- a/apis/outlook/mail/code/pkg/graph/mail.go
+++ b/apis/outlook/mail/code/pkg/graph/mail.go
@@ -36,6 +36,10 @@ func GetMessageDetails(ctx context.Context, client *msgraphsdkgo.GraphServiceCli
 }
 
 func SearchMessages(ctx context.Context, client *msgraphsdkgo.GraphServiceClient, query, folderID string) ([]models.Messageable, error) {
+	// We search specifically by subject using $filter and then using $search.
+	// The search results from $search are often not all that great for whatever reason. The subject line is probably more important.
+	// So we combine the results with the subject ones first, and then dedupe and return.
+
 	var (
 		subjectResult models.MessageCollectionResponseable
 		subjectErr    error

--- a/apis/outlook/mail/code/pkg/graph/mail.go
+++ b/apis/outlook/mail/code/pkg/graph/mail.go
@@ -35,46 +35,65 @@ func GetMessageDetails(ctx context.Context, client *msgraphsdkgo.GraphServiceCli
 	return result, nil
 }
 
-func SearchMessages(ctx context.Context, client *msgraphsdkgo.GraphServiceClient, query, folderID string) ([]models.Messageable, error) {
+func SearchMessages(ctx context.Context, client *msgraphsdkgo.GraphServiceClient, query, fromAddress, fromName, folderID string) ([]models.Messageable, error) {
+	if query == "" && fromAddress == "" && fromName == "" {
+		return nil, fmt.Errorf("at least one of query, from_address, or from_name must be provided")
+	}
+
 	// We search specifically by subject using $filter and then using $search.
 	// The search results from $search are often not all that great for whatever reason. The subject line is probably more important.
 	// So we combine the results with the subject ones first, and then dedupe and return.
-
 	var (
-		subjectResult models.MessageCollectionResponseable
-		subjectErr    error
-		result        models.MessageCollectionResponseable
-		err           error
+		subjectResult  models.MessageCollectionResponseable = &models.MessageCollectionResponse{}
+		subjectErr     error
+		result         models.MessageCollectionResponseable = &models.MessageCollectionResponse{}
+		err            error
+		filter, search string
 	)
+
+	if query != "" {
+		search = query
+		filter = fmt.Sprintf("contains(subject, '%s')", query)
+	}
+	if fromAddress != "" {
+		filter += fmt.Sprintf(" and contains(from/emailAddress/address, '%s')", fromAddress)
+	}
+	if fromName != "" {
+		filter += fmt.Sprintf(" and contains(from/emailAddress/name, '%s')", fromName)
+	}
 
 	if folderID != "" {
 		subjectResult, subjectErr = client.Me().MailFolders().ByMailFolderId(folderID).Messages().Get(ctx, &users.ItemMailFoldersItemMessagesRequestBuilderGetRequestConfiguration{
 			QueryParameters: &users.ItemMailFoldersItemMessagesRequestBuilderGetQueryParameters{
-				Filter: util.Ptr(fmt.Sprintf("contains(subject, '%s')", query)),
+				Filter: util.Ptr(filter),
 				Top:    util.Ptr(int32(10)),
 			},
 		})
 
-		result, err = client.Me().MailFolders().ByMailFolderId(folderID).Messages().Get(ctx, &users.ItemMailFoldersItemMessagesRequestBuilderGetRequestConfiguration{
-			QueryParameters: &users.ItemMailFoldersItemMessagesRequestBuilderGetQueryParameters{
-				Search: &query,
-				Top:    util.Ptr(int32(10)),
-			},
-		})
+		if search != "" {
+			result, err = client.Me().MailFolders().ByMailFolderId(folderID).Messages().Get(ctx, &users.ItemMailFoldersItemMessagesRequestBuilderGetRequestConfiguration{
+				QueryParameters: &users.ItemMailFoldersItemMessagesRequestBuilderGetQueryParameters{
+					Search: &search,
+					Top:    util.Ptr(int32(10)),
+				},
+			})
+		}
 	} else {
 		subjectResult, subjectErr = client.Me().Messages().Get(ctx, &users.ItemMessagesRequestBuilderGetRequestConfiguration{
 			QueryParameters: &users.ItemMessagesRequestBuilderGetQueryParameters{
-				Filter: util.Ptr(fmt.Sprintf("contains(subject, '%s')", query)),
+				Filter: util.Ptr(filter),
 				Top:    util.Ptr(int32(10)),
 			},
 		})
 
-		result, err = client.Me().Messages().Get(ctx, &users.ItemMessagesRequestBuilderGetRequestConfiguration{
-			QueryParameters: &users.ItemMessagesRequestBuilderGetQueryParameters{
-				Search: &query,
-				Top:    util.Ptr(int32(10)),
-			},
-		})
+		if search != "" {
+			result, err = client.Me().Messages().Get(ctx, &users.ItemMessagesRequestBuilderGetRequestConfiguration{
+				QueryParameters: &users.ItemMessagesRequestBuilderGetQueryParameters{
+					Search: &search,
+					Top:    util.Ptr(int32(10)),
+				},
+			})
+		}
 	}
 
 	if subjectErr != nil {

--- a/apis/outlook/mail/code/pkg/graph/mail.go
+++ b/apis/outlook/mail/code/pkg/graph/mail.go
@@ -106,8 +106,12 @@ func SearchMessages(ctx context.Context, client *msgraphsdkgo.GraphServiceClient
 	}
 
 	var fullResults []models.Messageable
-	fullResults = append(fullResults, subjectResult.GetValue()...)
-	fullResults = append(fullResults, result.GetValue()...)
+	if subjectResult != nil {
+		fullResults = append(fullResults, subjectResult.GetValue()...)
+	}
+	if result != nil {
+		fullResults = append(fullResults, result.GetValue()...)
+	}
 	return util.Dedupe(fullResults, func(result models.Messageable) string {
 		return util.Deref(result.GetId())
 	}), nil

--- a/apis/outlook/mail/code/pkg/util/util.go
+++ b/apis/outlook/mail/code/pkg/util/util.go
@@ -18,3 +18,16 @@ func Map[T, U any](arr []T, f func(T) U) []U {
 	}
 	return out
 }
+
+func Dedupe[T any, U comparable](arr []T, f func(T) U) []T {
+	seen := make(map[U]struct{})
+	var out []T
+	for _, v := range arr {
+		key := f(v)
+		if _, ok := seen[key]; !ok {
+			seen[key] = struct{}{}
+			out = append(out, v)
+		}
+	}
+	return out
+}

--- a/apis/outlook/mail/code/pkg/util/util.go
+++ b/apis/outlook/mail/code/pkg/util/util.go
@@ -18,16 +18,3 @@ func Map[T, U any](arr []T, f func(T) U) []U {
 	}
 	return out
 }
-
-func Dedupe[T any, U comparable](arr []T, f func(T) U) []T {
-	seen := make(map[U]struct{})
-	var out []T
-	for _, v := range arr {
-		key := f(v)
-		if _, ok := seen[key]; !ok {
-			seen[key] = struct{}{}
-			out = append(out, v)
-		}
-	}
-	return out
-}

--- a/apis/outlook/mail/code/tool.gpt
+++ b/apis/outlook/mail/code/tool.gpt
@@ -19,8 +19,10 @@ Param: message_id: The ID of the message to get details for.
 
 ---
 Name: searchMessages
-Description: Search for messages.
-Param: query: The search query to use.
+Description: Search for messages. At least one of query, fromAddress, or fromName must be specified.
+Param: query: (Optional) The search query to use. Must be plaintext with no special characters. This field will only search subject and message body.
+Param: from_address: (Optional) The email address to search for in the "From" field.
+Param: from_name: (Optional) The name to search for in the "From" field.
 Param: folder_id: (Optional) The ID of the folder to search in. If unset, will search all folders.
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool searchMessages

--- a/apis/outlook/mail/code/tool.gpt
+++ b/apis/outlook/mail/code/tool.gpt
@@ -19,7 +19,7 @@ Param: message_id: The ID of the message to get details for.
 
 ---
 Name: searchMessages
-Description: Search for messages. At least one of subject, fromAddress, or fromName must be specified.
+Description: Search for messages. At least one of subject, from_address, or from_name must be specified.
 Param: subject: (Optional) Search query for the subject of the message.
 Param: from_address: (Optional) Search query for the email address of the sender.
 Param: from_name: (Optional) Search query for the name of the sender.

--- a/apis/outlook/mail/code/tool.gpt
+++ b/apis/outlook/mail/code/tool.gpt
@@ -19,10 +19,10 @@ Param: message_id: The ID of the message to get details for.
 
 ---
 Name: searchMessages
-Description: Search for messages. At least one of query, fromAddress, or fromName must be specified.
-Param: query: (Optional) The search query to use. Must be plaintext with no special characters. This field will only search subject and message body.
-Param: from_address: (Optional) The email address to search for in the "From" field.
-Param: from_name: (Optional) The name to search for in the "From" field.
+Description: Search for messages. At least one of subject, fromAddress, or fromName must be specified.
+Param: subject: (Optional) Search query for the subject of the message.
+Param: from_address: (Optional) Search query for the email address of the sender.
+Param: from_name: (Optional) Search query for the name of the sender.
 Param: folder_id: (Optional) The ID of the folder to search in. If unset, will search all folders.
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool searchMessages


### PR DESCRIPTION
for gptscript-ai/desktop#199

This PR improves the experience searching for emails. Rather than using a generic search query that often returns irrelevant results, we now allow the LLM to search specifically by subject, sender email address, and/or sender full name. This should produce much more relevant search results.