### PR TITLE
more Slack improvements

### DIFF
--- a/apis/slack/code/index.js
+++ b/apis/slack/code/index.js
@@ -36,6 +36,9 @@ switch (command) {
   case "getChannelHistory":
     await getChannelHistory(webClient, process.env.CHANNELID, process.env.LIMIT)
     break
+  case "getChannelHistoryByTime":
+    await getChannelHistory(webClient, process.env.CHANNELID, process.env.LIMIT, process.env.START, process.env.END)
+    break
   case "getThreadHistory":
     await getThreadHistory(webClient, process.env.CHANNELID, process.env.THREADID, process.env.LIMIT)
     break

--- a/apis/slack/code/index.js
+++ b/apis/slack/code/index.js
@@ -1,6 +1,6 @@
 import { WebClient } from "@slack/web-api"
 import {
-  getChannelHistory,
+  getChannelHistory, getChannelHistoryByTime,
   getDMHistory,
   getDMThreadHistory,
   getMessageLink,
@@ -37,7 +37,7 @@ switch (command) {
     await getChannelHistory(webClient, process.env.CHANNELID, process.env.LIMIT)
     break
   case "getChannelHistoryByTime":
-    await getChannelHistory(webClient, process.env.CHANNELID, process.env.LIMIT, process.env.START, process.env.END)
+    await getChannelHistoryByTime(webClient, process.env.CHANNELID, process.env.LIMIT, process.env.START, process.env.END)
     break
   case "getThreadHistory":
     await getThreadHistory(webClient, process.env.CHANNELID, process.env.THREADID, process.env.LIMIT)

--- a/apis/slack/code/src/tools.js
+++ b/apis/slack/code/src/tools.js
@@ -32,7 +32,7 @@ export async function searchChannels(webClient, query) {
 export async function getChannelHistory(webClient, channelId, limit) {
     const history = await webClient.conversations.history({channel: channelId, limit: limit})
     if (!history.ok) {
-        console.error(`Failed to retrieve chat history: ${history.error}`)
+        console.log(`Failed to retrieve chat history: ${history.error}`)
         process.exit(1)
     } else if (history.messages.length === 0) {
         console.log('No messages found')
@@ -47,7 +47,7 @@ export async function getChannelHistoryByTime(webClient, channelId, limit, start
     const latest = new Date(end).getTime() / 1000
     const history = await webClient.conversations.history({channel: channelId, limit: limit, oldest: oldest.toString(), latest: latest.toString()})
     if (!history.ok) {
-        console.error(`Failed to retrieve chat history: ${history.error}`)
+        console.log(`Failed to retrieve chat history: ${history.error}`)
         process.exit(1)
     } else if (history.messages.length === 0) {
         console.log('No messages found')
@@ -60,7 +60,7 @@ export async function getChannelHistoryByTime(webClient, channelId, limit, start
 export async function getThreadHistory(webClient, channelId, threadId, limit) {
     const replies = await webClient.conversations.replies({channel: channelId, ts: threadId, limit: limit})
     if (!replies.ok) {
-        console.error(`Failed to retrieve thread history: ${replies.error}`)
+        console.log(`Failed to retrieve thread history: ${replies.error}`)
         process.exit(1)
     } else if (replies.messages.length === 0) {
         console.log('No messages found')
@@ -79,7 +79,7 @@ export async function search(webClient, query) {
     })
 
     if (!result.ok) {
-        console.error(`Failed to search messages: ${result.error}`)
+        console.log(`Failed to search messages: ${result.error}`)
         process.exit(1)
     }
 
@@ -100,7 +100,7 @@ export async function sendMessage(webClient, channelId, text) {
     })
 
     if (!result.ok) {
-        console.error(`Failed to send message: ${result.error}`)
+        console.log(`Failed to send message: ${result.error}`)
         process.exit(1)
     }
     console.log('Message sent successfully')
@@ -114,7 +114,7 @@ export async function sendMessageInThread(webClient, channelId, threadTs, text) 
     })
 
     if (!result.ok) {
-        console.error(`Failed to send message: ${result.error}`)
+        console.log(`Failed to send message: ${result.error}`)
         process.exit(1)
     }
     console.log('Thread message sent successfully')
@@ -170,7 +170,7 @@ export async function getMessageLink(webClient, channelId, messageId) {
     })
 
     if (!result.ok) {
-        console.error(`Failed to get message link: ${result.error}`)
+        console.log(`Failed to get message link: ${result.error}`)
         process.exit(1)
     }
 
@@ -188,7 +188,7 @@ export async function getDMHistory(webClient, userIds, limit) {
     })
 
     if (!history.ok) {
-        console.error(`Failed to retrieve chat history: ${history.error}`)
+        console.log(`Failed to retrieve chat history: ${history.error}`)
         process.exit(1)
     }
 
@@ -212,7 +212,7 @@ export async function getDMThreadHistory(webClient, userIds, threadId, limit) {
     })
 
     if (!replies.ok) {
-        console.error(`Failed to retrieve thread history: ${replies.error}`)
+        console.log(`Failed to retrieve thread history: ${replies.error}`)
         process.exit(1)
     }
 

--- a/apis/slack/code/src/tools.js
+++ b/apis/slack/code/src/tools.js
@@ -1,5 +1,3 @@
-import {BlockType} from "@slack/web-api/dist/types/response/RtmStartResponse.js";
-
 export async function listChannels(webClient) {
     const channels = await webClient.conversations.list({limit: 100, types: 'public_channel'})
     console.log('Public channels:')

--- a/apis/slack/code/src/tools.js
+++ b/apis/slack/code/src/tools.js
@@ -197,7 +197,9 @@ export async function getDMHistory(webClient, userIds, limit) {
         return
     }
 
-    await printHistory(webClient, res.channel.id, history)
+    for (const message of history.messages) {
+        await printMessage(webClient, message)
+    }
 }
 
 export async function getDMThreadHistory(webClient, userIds, threadId, limit) {
@@ -221,7 +223,9 @@ export async function getDMThreadHistory(webClient, userIds, threadId, limit) {
         return
     }
 
-    await printHistory(webClient, res.channel.id, replies)
+    for (const reply of replies.messages) {
+        await printMessage(webClient, reply)
+    }
 }
 
 // Helper functions below

--- a/apis/slack/code/tool.gpt
+++ b/apis/slack/code/tool.gpt
@@ -14,9 +14,19 @@ Param: query: the search query
 Name: get_channel_history
 Description: Get the chat history for a channel in the Slack workspace
 Param: channelid: the ID of the channel to get the history for
-Param: limit: the number of messages to return
+Param: limit: the number of messages to return - recommend starting with 10 and increasing if necessary
 
 #!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js getChannelHistory
+
+---
+Name: get_channel_history_by_time
+Description: Get the chat history for a channel in the Slack workspace within a specific time range
+Param: channelid: the ID of the channel to get the history for
+Param: limit: the maximum number of messages to return - recommend starting with 10 and increasing if necessary
+Param: start: the start time in RFC 3339 format
+Param: end: the end time in RFC 3339 format
+
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js getChannelHistoryByTime
 
 ---
 Name: get_thread_history

--- a/apis/slack/read/tool.gpt
+++ b/apis/slack/read/tool.gpt
@@ -6,6 +6,7 @@ Share Tools: search_channels from github.com/gptscript-ai/tools/apis/slack/code
 Share Tools: list_users from github.com/gptscript-ai/tools/apis/slack/code
 Share Tools: search_users from github.com/gptscript-ai/tools/apis/slack/code
 Share Tools: get_channel_history from github.com/gptscript-ai/tools/apis/slack/code
+Share Tools: get_channel_history_by_time from github.com/gptscript-ai/tools/apis/slack/code
 Share Tools: get_thread_history from github.com/gptscript-ai/tools/apis/slack/code
 Share Tools: search_messages from github.com/gptscript-ai/tools/apis/slack/code
 Share Tools: get_message_link from github.com/gptscript-ai/tools/apis/slack/code


### PR DESCRIPTION
This PR:
- adds a `get_channel_history_by_time` tool that lets you set start and end time parameters
- prints errors to stdout instead of stderr
- improves output of messages by including more information
- encourages the LLM to set a limit of 10 by default when querying for channel history, to avoid taking too much time