### PR TITLE
fix: outlook mail: encourage the LLM to include the body preview in output

### DIFF
--- a/apis/outlook/mail/manage/tool.gpt
+++ b/apis/outlook/mail/manage/tool.gpt
@@ -9,3 +9,4 @@ Type: context
 
 You have access to a collection of operations in the Microsoft Outlook Mail API.
 Do not output mail folder IDs or message IDs because they are not helpful for the user.
+When printing a list of messages for the user, include the body preview. When printing a single message and its details, print the full body.

--- a/apis/outlook/mail/read/tool.gpt
+++ b/apis/outlook/mail/read/tool.gpt
@@ -12,3 +12,4 @@ Type: context
 
 You have access to a collection of operations in the Microsoft Outlook Mail API.
 Do not output mail folder IDs or message IDs because they are not helpful for the user.
+When printing a list of messages for the user, include the body preview. When printing a single message and its details, print the full body.


### PR DESCRIPTION
Just a little prompting tweak.