### PR TITLE
enhance: remove list issues and prs commands

### DIFF
--- a/apis/github/code/index.js
+++ b/apis/github/code/index.js
@@ -1,5 +1,5 @@
 import { Octokit } from '@octokit/rest';
-import { listIssues, listPRs, createIssue, modifyIssue, deleteIssue, searchIssues, createPR, modifyPR, deletePR, addCommentToIssue, addCommentToPR, getIssue, getPR, getIssueComments, getPRComments, listRepos, closeIssue } from './src/tools.js';
+import { createIssue, modifyIssue, deleteIssue, searchIssuesAndPRs, createPR, modifyPR, deletePR, addCommentToIssue, addCommentToPR, getIssue, getPR, getIssueComments, getPRComments, listRepos, closeIssue } from './src/tools.js';
 
 if (process.argv.length !== 3) {
     console.log('Usage: node index.js <command>');
@@ -18,12 +18,6 @@ const octokit = new Octokit({ auth: token });
 
 try {
     switch (command) {
-        case 'listIssues':
-            await listIssues(octokit, process.env.OWNER, process.env.REPO);
-            break;
-        case 'listPRs':
-            await listPRs(octokit, process.env.OWNER, process.env.REPO);
-            break;
         case 'createIssue':
             await createIssue(octokit, process.env.OWNER, process.env.REPO, process.env.TITLE, process.env.BODY);
             break;
@@ -33,8 +27,8 @@ try {
         case 'deleteIssue':
             await deleteIssue(octokit, process.env.OWNER, process.env.REPO, process.env.ISSUENUMBER);
             break;
-        case 'searchIssues':
-            await searchIssues(octokit, process.env.OWNER, process.env.REPO, process.env.QUERY);
+        case 'searchIssuesAndPRs':
+            await searchIssuesAndPRs(octokit, process.env.OWNER, process.env.REPO, process.env.QUERY);
             break;
         case 'createPR':
             await createPR(octokit, process.env.OWNER, process.env.REPO, process.env.TITLE, process.env.BODY, process.env.HEAD, process.env.BASE);

--- a/apis/github/code/tool.gpt
+++ b/apis/github/code/tool.gpt
@@ -1,18 +1,3 @@
-Name: list_issues
-Description: List all open issues in the specified GitHub repository. Returns the issue number, title, and ID for each issue
-Param: owner: the owner of the repository
-Param: repo: the name of the repository
-
-#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js listIssues
-
----
-Name: list_prs
-Description: List all open pull requests in the specified GitHub repository. Returns the PR number, title, and ID for each PR
-Param: owner: the owner of the repository
-Param: repo: the name of the repository
-
-#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js listPRs
-
 ---
 Name: create_issue
 Description: Create a new issue in the specified GitHub repository
@@ -44,13 +29,13 @@ Param: issueNumber: the number of the issue to delete
 #!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js deleteIssue
 
 ---
-Name: search_issues
-Description: Search for issues in the specified GitHub repository
-Param: owner: the owner of the repository
-Param: repo: the name of the repository
-Param: query: the search query
+Name: search_issues_and_prs
+Description: Search for issues and PRs in GitHub
+Param: owner: (optional) the owner of the repository the issues or PRs belong to
+Param: repo: (optional) the name of the repository the issues or PRs belong to
+Param: query: the Github search query
 
-#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js searchIssues
+#!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js searchIssuesAndPRs
 
 ---
 Name: create_pr

--- a/apis/github/read/tool.gpt
+++ b/apis/github/read/tool.gpt
@@ -1,9 +1,7 @@
 Name: Read GitHub
 Description: Provides read-only access to the GitHub API
 Share Credential: github.com/gptscript-ai/gateway-oauth2 as github.read with GITHUB_TOKEN as env and GitHub as integration and "repo" as scope
-Share Tools: list_issues from github.com/gptscript-ai/tools/apis/github/code
-Share Tools: list_prs from github.com/gptscript-ai/tools/apis/github/code
-Share Tools: search_issues from github.com/gptscript-ai/tools/apis/github/code
+Share Tools: search_issues_and_prs from github.com/gptscript-ai/tools/apis/github/code
 Share Tools: get_issue from github.com/gptscript-ai/tools/apis/github/code
 Share Tools: get_pr from github.com/gptscript-ai/tools/apis/github/code
 Share Tools: get_issue_comments from github.com/gptscript-ai/tools/apis/github/code


### PR DESCRIPTION
Issue search can be used to list issues and PRs with better results than
the basic list commands. One of the core problems is that these list
commands only return open issues and PRs. Remove them in favor of
relying on issue search.

