### PR TITLE
fix: excel: share the tools

### DIFF
--- a/apis/excel/read/tool.gpt
+++ b/apis/excel/read/tool.gpt
@@ -1,6 +1,6 @@
-Tools: listWorkbooks from ../code
-Tools: listWorksheets from ../code
-Tools: getWorksheetData from ../code
+Share Tools: listWorkbooks from ../code
+Share Tools: listWorksheets from ../code
+Share Tools: getWorksheetData from ../code
 Type: context
 
 #!sys.echo

--- a/apis/excel/write/tool.gpt
+++ b/apis/excel/write/tool.gpt
@@ -1,4 +1,4 @@
-Tools: * from ../code
+Share Tools: * from ../code
 Type: context
 
 #!sys.echo


### PR DESCRIPTION
Just noticed this today. These tool sets are supposed to share the tools, which they weren't doing.