### PR TITLE
chore: outlook: define credentials on each tool

### DIFF
--- a/apis/outlook/calendar/code/tool.gpt
+++ b/apis/outlook/calendar/code/tool.gpt
@@ -1,17 +1,20 @@
 Name: listCalendars
 Description: List all calendars available to the user.
+Credential: github.com/gptscript-ai/gateway-oauth2 as outlook.calendar.read with GPTSCRIPT_GRAPH_MICROSOFT_COM_BEARER_TOKEN as env and microsoft365 as integration and "Calendars.Read Calendars.Read.Shared Group.Read.All GroupMember.Read.All User.Read offline_access" as scope
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool listCalendars
 
 ---
 Name: listEventsToday
 Description: List all events for today in all calendars available to the user.
+Credential: github.com/gptscript-ai/gateway-oauth2 as outlook.calendar.read with GPTSCRIPT_GRAPH_MICROSOFT_COM_BEARER_TOKEN as env and microsoft365 as integration and "Calendars.Read Calendars.Read.Shared Group.Read.All GroupMember.Read.All User.Read offline_access" as scope
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool listEventsToday
 
 ---
 Name: listEvents
 Description: List all events in the given time frame in all calendars available to the user.
+Credential: github.com/gptscript-ai/gateway-oauth2 as outlook.calendar.read with GPTSCRIPT_GRAPH_MICROSOFT_COM_BEARER_TOKEN as env and microsoft365 as integration and "Calendars.Read Calendars.Read.Shared Group.Read.All GroupMember.Read.All User.Read offline_access" as scope
 Param: start: The start date and time of the time frame, in RFC 3339 format.
 Param: end: The end date and time of the time frame, in RFC 3339 format.
 
@@ -20,6 +23,7 @@ Param: end: The end date and time of the time frame, in RFC 3339 format.
 ---
 Name: getEventDetails
 Description: Get the details for a particular event.
+Credential: github.com/gptscript-ai/gateway-oauth2 as outlook.calendar.read with GPTSCRIPT_GRAPH_MICROSOFT_COM_BEARER_TOKEN as env and microsoft365 as integration and "Calendars.Read Calendars.Read.Shared Group.Read.All GroupMember.Read.All User.Read offline_access" as scope
 Param: event_id: The unique ID of the event.
 Param: calendar_id: The unique ID of the calendar or group the event belongs to. If unset, uses the default calendar.
 Param: owner_type: The type of the owner of the calendar or group. Possible values are "user" or "group". Required if calendar_id is set.
@@ -29,6 +33,7 @@ Param: owner_type: The type of the owner of the calendar or group. Possible valu
 ---
 Name: createEvent
 Description: Create a new event.
+Credential: github.com/gptscript-ai/gateway-oauth2 as outlook.calendar.manage with GPTSCRIPT_GRAPH_MICROSOFT_COM_BEARER_TOKEN as env and microsoft365 as integration and "Calendars.Read Calendars.Read.Shared Calendars.ReadWrite Calendars.ReadWrite.Shared Group.Read.All Group.ReadWrite.All GroupMember.Read.All User.Read offline_access" as scope
 Param: subject: (Required) The title of the event.
 Param: location: (Required) The location of the event.
 Param: body: (Required) The details of the event.
@@ -44,6 +49,7 @@ Param: owner_type: The type of the owner of the calendar or group. Possible valu
 ---
 Name: inviteUserToEvent
 Description: Invites another person to an existing event.
+Credential: github.com/gptscript-ai/gateway-oauth2 as outlook.calendar.manage with GPTSCRIPT_GRAPH_MICROSOFT_COM_BEARER_TOKEN as env and microsoft365 as integration and "Calendars.Read Calendars.Read.Shared Calendars.ReadWrite Calendars.ReadWrite.Shared Group.Read.All Group.ReadWrite.All GroupMember.Read.All User.Read offline_access" as scope
 Param: event_id: The unique ID of the event.
 Param: calendar_id: The unique ID of the calendar or group the event belongs to. If unset, uses the default calendar.
 Param: owner_type: The type of the owner of the calendar or group. Possible values are "user" or "group". Required if calendar_id is set.
@@ -55,6 +61,7 @@ Param: message: The message to send along with the invite.
 ---
 Name: deleteEvent
 Description: Deletes an event.
+Credential: github.com/gptscript-ai/gateway-oauth2 as outlook.calendar.manage with GPTSCRIPT_GRAPH_MICROSOFT_COM_BEARER_TOKEN as env and microsoft365 as integration and "Calendars.Read Calendars.Read.Shared Calendars.ReadWrite Calendars.ReadWrite.Shared Group.Read.All Group.ReadWrite.All GroupMember.Read.All User.Read offline_access" as scope
 Param: event_id: The unique ID of the event.
 Param: calendar_id: The unique ID of the calendar or group the event belongs to. If unset, uses the default calendar.
 Param: owner_type: The type of the owner of the calendar or group. Possible values are "user" or "group". Required if calendar_id is set.
@@ -64,6 +71,7 @@ Param: owner_type: The type of the owner of the calendar or group. Possible valu
 ---
 Name: searchEvents
 Description: Search for events based on a query string.
+Credential: github.com/gptscript-ai/gateway-oauth2 as outlook.calendar.read with GPTSCRIPT_GRAPH_MICROSOFT_COM_BEARER_TOKEN as env and microsoft365 as integration and "Calendars.Read Calendars.Read.Shared Group.Read.All GroupMember.Read.All User.Read offline_access" as scope
 Param: query: (Required) The search query.
 Param: start: (Required) The start date and time of the time frame to search within, in RFC 3339 format.
 Param: end: (Required) The end date and time of the time frame to search within, in RFC 3339 format.
@@ -73,6 +81,7 @@ Param: end: (Required) The end date and time of the time frame to search within,
 ---
 Name: respondToEvent
 Description: Accept, tentatively accept, or decline an event invitation.
+Credential: github.com/gptscript-ai/gateway-oauth2 as outlook.calendar.manage with GPTSCRIPT_GRAPH_MICROSOFT_COM_BEARER_TOKEN as env and microsoft365 as integration and "Calendars.Read Calendars.Read.Shared Calendars.ReadWrite Calendars.ReadWrite.Shared Group.Read.All Group.ReadWrite.All GroupMember.Read.All User.Read offline_access" as scope
 Param: event_id: The unique ID of the event.
 Param: calendar_id: The unique ID of the calendar or group the event belongs to. If unset, uses the default calendar.
 Param: owner_type: The type of the owner of the calendar or group. Possible values are "user" or "group". Required if calendar_id is set.

--- a/apis/outlook/calendar/manage/tool.gpt
+++ b/apis/outlook/calendar/manage/tool.gpt
@@ -2,7 +2,6 @@ Name: Manage Outlook Calendar
 Description: Provides access to the Microsoft Outlook Calendar API
 Share Context: github.com/gptscript-ai/context/current-time
 Share Tools: * from github.com/gptscript-ai/tools/apis/outlook/calendar/code
-Share Credential: github.com/gptscript-ai/gateway-oauth2 as outlook.calendar.manage with GPTSCRIPT_GRAPH_MICROSOFT_COM_BEARER_TOKEN as env and microsoft365 as integration and "Calendars.Read Calendars.Read.Shared Calendars.ReadWrite Calendars.ReadWrite.Shared Group.Read.All Group.ReadWrite.All GroupMember.Read.All User.Read offline_access" as scope
 Type: context
 
 #!sys.echo

--- a/apis/outlook/calendar/read/tool.gpt
+++ b/apis/outlook/calendar/read/tool.gpt
@@ -6,7 +6,6 @@ Share Tools: listEventsToday from github.com/gptscript-ai/tools/apis/outlook/cal
 Share Tools: listEvents from github.com/gptscript-ai/tools/apis/outlook/calendar/code
 Share Tools: getEventDetails from github.com/gptscript-ai/tools/apis/outlook/calendar/code
 Share Tools: searchEvents from github.com/gptscript-ai/tools/apis/outlook/calendar/code
-Share Credential: github.com/gptscript-ai/gateway-oauth2 as outlook.calendar.read with GPTSCRIPT_GRAPH_MICROSOFT_COM_BEARER_TOKEN as env and microsoft365 as integration and "Calendars.Read Calendars.Read.Shared Group.Read.All GroupMember.Read.All User.Read offline_access" as scope
 Type: context
 
 #!sys.echo

--- a/apis/outlook/mail/code/tool.gpt
+++ b/apis/outlook/mail/code/tool.gpt
@@ -1,11 +1,13 @@
 Name: listMailFolders
 Description: Lists all available mail folders.
+Credential: github.com/gptscript-ai/gateway-oauth2 as outlook.mail.read with GPTSCRIPT_GRAPH_MICROSOFT_COM_BEARER_TOKEN as env and microsoft365 as integration and "Mail.Read User.Read offline_access" as scope
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool listMailFolders
 
 ---
 Name: listMessages
 Description: Lists all messages in a folder.
+Credential: github.com/gptscript-ai/gateway-oauth2 as outlook.mail.read with GPTSCRIPT_GRAPH_MICROSOFT_COM_BEARER_TOKEN as env and microsoft365 as integration and "Mail.Read User.Read offline_access" as scope
 Param: folder_id: The ID of the folder to list messages in.
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool listMessages
@@ -13,6 +15,7 @@ Param: folder_id: The ID of the folder to list messages in.
 ---
 Name: getMessageDetails
 Description: Get the details of a message.
+Credential: github.com/gptscript-ai/gateway-oauth2 as outlook.mail.read with GPTSCRIPT_GRAPH_MICROSOFT_COM_BEARER_TOKEN as env and microsoft365 as integration and "Mail.Read User.Read offline_access" as scope
 Param: message_id: The ID of the message to get details for.
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool getMessageDetails
@@ -20,6 +23,7 @@ Param: message_id: The ID of the message to get details for.
 ---
 Name: searchMessages
 Description: Search for messages. At least one of subject, from_address, or from_name must be specified.
+Credential: github.com/gptscript-ai/gateway-oauth2 as outlook.mail.read with GPTSCRIPT_GRAPH_MICROSOFT_COM_BEARER_TOKEN as env and microsoft365 as integration and "Mail.Read User.Read offline_access" as scope
 Param: subject: (Optional) Search query for the subject of the message.
 Param: from_address: (Optional) Search query for the email address of the sender.
 Param: from_name: (Optional) Search query for the name of the sender.
@@ -30,6 +34,7 @@ Param: folder_id: (Optional) The ID of the folder to search in. If unset, will s
 ---
 Name: createDraft
 Description: Create (but do not send) a draft message.
+Credential: github.com/gptscript-ai/gateway-oauth2 as outlook.mail.manage with GPTSCRIPT_GRAPH_MICROSOFT_COM_BEARER_TOKEN as env and microsoft365 as integration and "Mail.Read Mail.ReadWrite Mail.Send User.Read offline_access" as scope
 Param: subject: The subject of the message.
 Param: content: The content of the message in HTML.
 Param: recipients: A comma-separated list of email addresses to send the message to. No spaces. Example: person1@example.com,person2@example.com
@@ -41,6 +46,7 @@ Param: bcc: (Optional) A comma-separated list of email addresses to BCC on the m
 ---
 Name: sendDraft
 Description: Send an existing draft message.
+Credential: github.com/gptscript-ai/gateway-oauth2 as outlook.mail.manage with GPTSCRIPT_GRAPH_MICROSOFT_COM_BEARER_TOKEN as env and microsoft365 as integration and "Mail.Read Mail.ReadWrite Mail.Send User.Read offline_access" as scope
 Param: draft_id: The ID of the draft to send.
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool sendDraft
@@ -48,6 +54,7 @@ Param: draft_id: The ID of the draft to send.
 ---
 Name: deleteMessage
 Description: Delete a message.
+Credential: github.com/gptscript-ai/gateway-oauth2 as outlook.mail.manage with GPTSCRIPT_GRAPH_MICROSOFT_COM_BEARER_TOKEN as env and microsoft365 as integration and "Mail.Read Mail.ReadWrite Mail.Send User.Read offline_access" as scope
 Param: message_id: The ID of the message to delete. This is NOT a mail folder ID.
 
 #!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool deleteMessage
@@ -55,6 +62,7 @@ Param: message_id: The ID of the message to delete. This is NOT a mail folder ID
 ---
 Name: moveMessage
 Description: Moves a message to a folder.
+Credential: github.com/gptscript-ai/gateway-oauth2 as outlook.mail.manage with GPTSCRIPT_GRAPH_MICROSOFT_COM_BEARER_TOKEN as env and microsoft365 as integration and "Mail.Read Mail.ReadWrite Mail.Send User.Read offline_access" as scope
 Param: message_id: The ID of the message to move.
 Param: destination_folder_id: The ID of the folder to move the message into.
 

--- a/apis/outlook/mail/manage/tool.gpt
+++ b/apis/outlook/mail/manage/tool.gpt
@@ -2,7 +2,6 @@ Name: Manage Outlook Mail
 Description: Provides access to the Microsoft Outlook Mail API
 Share Context: github.com/gptscript-ai/context/current-time
 Share Tools: * from github.com/gptscript-ai/tools/apis/outlook/mail/code
-Share Credential: github.com/gptscript-ai/gateway-oauth2 as outlook.mail.manage with GPTSCRIPT_GRAPH_MICROSOFT_COM_BEARER_TOKEN as env and microsoft365 as integration and "Mail.Read Mail.ReadWrite Mail.Send User.Read offline_access" as scope
 Type: context
 
 #!sys.echo

--- a/apis/outlook/mail/read/tool.gpt
+++ b/apis/outlook/mail/read/tool.gpt
@@ -5,7 +5,6 @@ Share Tools: listMailFolders from github.com/gptscript-ai/tools/apis/outlook/mai
 Share Tools: listMessages from github.com/gptscript-ai/tools/apis/outlook/mail/code
 Share Tools: getMessageDetails from github.com/gptscript-ai/tools/apis/outlook/mail/code
 Share Tools: searchMessages from github.com/gptscript-ai/tools/apis/outlook/mail/code
-Share Credential: github.com/gptscript-ai/gateway-oauth2 as outlook.mail.read with GPTSCRIPT_GRAPH_MICROSOFT_COM_BEARER_TOKEN as env and microsoft365 as integration and "Mail.Read User.Read offline_access" as scope
 Type: context
 
 #!sys.echo


### PR DESCRIPTION
As I was working on step templates, I realized it would be nice to be able to refer to individual tools from the `code` folder for each of these, which requires them to define their own credentials. We have been following this pattern for newer tools and it seems to be better than what we were doing before, so here is the PR to do this for the Outlook tools.