### PR TITLE
enhance: add pagination to the "Search Issues and PRs" tool

### DIFF
--- a/apis/github/index.js
+++ b/apis/github/index.js
@@ -28,7 +28,7 @@ try {
             await deleteIssue(octokit, process.env.OWNER, process.env.REPO, process.env.ISSUENUMBER);
             break;
         case 'searchIssuesAndPRs':
-            await searchIssuesAndPRs(octokit, process.env.OWNER, process.env.REPO, process.env.QUERY);
+            await searchIssuesAndPRs(octokit, process.env.OWNER, process.env.REPO, process.env.QUERY, process.env.PERPAGE, process.env.PAGE);
             break;
         case 'createPR':
             await createPR(octokit, process.env.OWNER, process.env.REPO, process.env.TITLE, process.env.BODY, process.env.HEAD, process.env.BASE);

--- a/apis/github/src/tools.js
+++ b/apis/github/src/tools.js
@@ -53,14 +53,11 @@ export async function deleteIssue(octokit, owner, repo, issueNumber) {
     console.log(`Deleted issue #${issueNumber} - https://github.com/${owner}/${repo}/issues/${issueNumber}`);
 }
 
-export async function searchIssuesAndPRs(octokit, owner, repo, query) {
+export async function searchIssuesAndPRs(octokit, owner, repo, query, perPage = 100, page = 1) {
     let q = '';
 
     if (owner) {
-        // Determine if the owner is a user or an organization
         const { data: { type } } = await octokit.users.getByUsername({ username: owner });
-
-        // Construct the query based on the presence of repo and owner type
         const ownerQualifier = type === 'User' ? `user:${owner}` : `org:${owner}`;
         q = repo ? `repo:${owner}/${repo}` : ownerQualifier;
     } else if (repo) {
@@ -73,10 +70,12 @@ export async function searchIssuesAndPRs(octokit, owner, repo, query) {
         q += ` ${query}`;
     }
 
-    // Search for issues and pull requests
-    const { data: { items } } = await octokit.search.issuesAndPullRequests({ q: q.trim() });
+    const { data: { items } } = await octokit.search.issuesAndPullRequests({
+        q: q.trim(),
+        per_page: perPage,
+        page: page
+    });
 
-    // Log the results
     items.forEach(issue => {
         console.log(`#${issue.number} - ${issue.title} (ID: ${issue.id}) - ${issue.html_url}`);
     });

--- a/apis/github/tool.gpt
+++ b/apis/github/tool.gpt
@@ -33,11 +33,13 @@ Param: issueNumber: the number of the issue to delete
 
 ---
 Name: Search Issues and PRs
-Description: Search for issues and PRs in GitHub
+Description: Search for issues and PRs in GitHub. Results are paginated, so in order to get all results for a search, call this function with the `page` parameter incremented by 1 until no results are returned.
 Credential: github.com/gptscript-ai/gateway-oauth2 as github.write with GITHUB_TOKEN as env and GitHub as integration and "repo" as scope
 Param: owner: (optional) the owner of the repository the issues or PRs belong to
 Param: repo: (optional) the name of the repository the issues or PRs belong to
 Param: query: the Github search query
+Param: perPage: (optional) number of results per page (default is 100)
+Param: page: (optional) page number of the results to fetch (default is 1)
 
 #!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js searchIssuesAndPRs
 


### PR DESCRIPTION
Searching issues and PRs with the GitHub "Search Issues and PRs" tool is currently limited by the default query result count. To fix this, add pagination to the tool so the LLM can discover all results for a given query.
