### PR TITLE
enhance: add category and icon metadata to tools

### DIFF
--- a/apis/excel/tool.gpt
+++ b/apis/excel/tool.gpt
@@ -66,3 +66,11 @@ You have access to a set of tools to access, create, and modify Microsoft Excel 
 Do not output workbook IDs or worksheet IDs because they are not helpful for the user.
 
 ## End of instructions for using Excel tools
+
+---
+!metadata:*:category
+Excel
+
+---
+!metadata:*:icon
+https://cdn.jsdelivr.net/npm/@phosphor-icons/core@2/assets/duotone/microsoft-excel-logo-duotone.svg

--- a/apis/github/tool.gpt
+++ b/apis/github/tool.gpt
@@ -166,3 +166,11 @@ Param: owner: the owner of the repository
 Param: repo: the name of the repository
 
 #!/usr/bin/env node ${GPTSCRIPT_TOOL_DIR}/index.js getStarCount
+
+---
+!metadata:*:category
+GitHub
+
+---
+!metadata:*:icon
+https://cdn.jsdelivr.net/npm/simple-icons@v13/icons/github.svg

--- a/apis/google/gmail/tool.gpt
+++ b/apis/google/gmail/tool.gpt
@@ -99,3 +99,11 @@ Credential: github.com/gptscript-ai/gateway-oauth2 as google.gmail.write with GM
 Param: draft_id: The ID of the draft email to send
 
 #!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/sendDraft.py
+
+---
+!metadata:*:category
+Gmail
+
+---
+!metadata:*:icon
+https://cdn.jsdelivr.net/npm/simple-icons@v13/icons/gmail.svg

--- a/apis/google/sheets/tool.gpt
+++ b/apis/google/sheets/tool.gpt
@@ -74,3 +74,11 @@ You have access to a set of tools to access, create, and modify Google Sheets.
 Do not output sheet IDs because they are not helpful for the user.
 
 ## End of instructions for using Google Sheets tools
+
+---
+!metadata:*:category
+Google Sheets
+
+---
+!metadata:*:icon
+https://cdn.jsdelivr.net/npm/simple-icons@v13/icons/googlesheets.svg

--- a/apis/google/youtube/tool.gpt
+++ b/apis/google/youtube/tool.gpt
@@ -24,3 +24,11 @@ Tools: github.com/gptscript-ai/context/workspace
 param: video_url: The URL of a YouTube video. (e.g. https://www.youtube.com/watch?v=VIDEO_ID or https://youtu.be/VIDEO_ID)
 
 #!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/advTranscriber.py
+
+---
+!metadata:*:category
+YouTube
+
+---
+!metadata:*:icon
+https://cdn.jsdelivr.net/npm/simple-icons@v13/icons/youtube.svg

--- a/apis/notion/tool.gpt
+++ b/apis/notion/tool.gpt
@@ -67,3 +67,11 @@ Args: rowId: the ID of the row to update
 Args: properties: a JSON string containing all of the key-value pairs to update
 
 #!/usr/bin/env node --no-warnings ${GPTSCRIPT_TOOL_DIR}/index.js updateDatabaseRow
+
+---
+!metadata:*:category
+Notion
+
+---
+!metadata:*:icon
+https://cdn.jsdelivr.net/npm/simple-icons@v13/icons/notion.svg

--- a/apis/outlook/calendar/tool.gpt
+++ b/apis/outlook/calendar/tool.gpt
@@ -119,3 +119,11 @@ Do not output calendar IDs or event IDs because they are not helpful for the use
 You don't know the user's timezone. If they ask you to create or modify events, get clarification about their timezone and use it. If creating a date/time in the UTC timezone, it must end with 'Z' to properly denote it's for UTC.
 
 ## End of instructions for using the Microsoft Outlook Calendar tools
+
+---
+!metadata:*:category
+Outlook Calendar
+
+---
+!metadata:*:icon
+https://cdn.jsdelivr.net/npm/@phosphor-icons/core@2/assets/duotone/calendar-duotone.svg

--- a/apis/outlook/mail/tool.gpt
+++ b/apis/outlook/mail/tool.gpt
@@ -98,3 +98,11 @@ When printing a list of messages for the user, include the body preview. When pr
 When printing a single message or a list of messages, use Markdown formatting.
 
 ## End of instructions for using the Microsoft Outlook Mail tools
+
+---
+!metadata:*:category
+Outlook Mail
+
+---
+!metadata:*:icon
+https://cdn.jsdelivr.net/npm/@phosphor-icons/core@2/assets/duotone/microsoft-outlook-logo-duotone.svg

--- a/apis/slack/tool.gpt
+++ b/apis/slack/tool.gpt
@@ -158,3 +158,11 @@ Do not provide channel, thread, or message IDs in the output, as these are not h
 When you use the search_messages tool, you can use normal Slack search filters. If you filter by user, use the full username, which can be obtained from the list_users or search_users tools.
 
 ## End of instructions for using Slack tools
+
+---
+!metadata:*:category
+Slack
+
+---
+!metadata:*:icon
+https://cdn.jsdelivr.net/npm/simple-icons@v13/icons/slack.svg


### PR DESCRIPTION
Add category and icon URL to tool set metadata. This will enable better tool
set search and the use of common icons across tools within each set.

Note: This doesn't include metadata for the hubspot tool. I believe that still needs to be refactored to collapse the read/write tools into a single tool. If so, I'll include the metadata in a separate refactor PR.